### PR TITLE
Make sure crate is no_std compatible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 //! assert_eq!(get_general_category('A'), GeneralCategory::UppercaseLetter);
 //! ```
 
+#![no_std]
+
 mod category;
 mod tables;
 pub use category::get_general_category;


### PR DESCRIPTION
Small fix, just adds `#![no_std]`. Preparation for https://github.com/yeslogic/allsorts/pull/42